### PR TITLE
chore: `tsc` error related to the ReactMarkdown import syntax in `Markdown.tsx`.

### DIFF
--- a/src/pages/admin/markdown/Markdown.tsx
+++ b/src/pages/admin/markdown/Markdown.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import * as ReactMarkdown from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
 import {
     Grid,
     Theme,


### PR DESCRIPTION
Fix `src/pages/admin/markdown/Markdown.tsx:77:26 - error TS2604: JSX element type 'ReactMarkdown' does not have any construct or call signatures.`
Related to, https://github.com/remarkjs/react-markdown/issues/207 -- Since the `tsconfig.json` already has `allowSyntheticDefaultImports: true` all that is needed to resolve this is to import it as the explicit import name instead of `* as ExplicitImportName`.