### PR TITLE
chore: `tsc` error related to the ReactMarkdown import syntax in `Home.tsx`.

### DIFF
--- a/src/pages/public/Home.tsx
+++ b/src/pages/public/Home.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as intl from 'react-intl-universal';
-import * as ReactMarkdown from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
 import { Dispatch, Action } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';


### PR DESCRIPTION
Fix `src/pages/public/Home.tsx:163:22 - error TS2604: JSX element type 'ReactMarkdown' does not have any construct or call signatures.`
Related to, https://github.com/remarkjs/react-markdown/issues/207 -- Since the `tsconfig.json` already has `allowSyntheticDefaultImports: true` all that is needed to resolve this is to import it as the explicit import name instead of `* as ExplicitImportName`.